### PR TITLE
Fix goreleaser config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 git-credential-ssm
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,8 +11,8 @@ builds:
     targets:
       - darwin_arm64
       - darwin_amd64
-      - linux_amd64
       - linux_arm64
+      - linux_amd64
     env:
         - CGO_ENABLED=0
     flags:
@@ -22,7 +22,10 @@ builds:
 archives:
   - format: gz
     name_template: >-
-      {{ .ProjectName }}_{{ .Os }}_{{ .Arch }}
+      {{ .ProjectName }}_{{ .Os }}_{{ .Arch }}_v{{ .Version }}
+    # https://goreleaser.com/customization/archive/#packaging-only-the-binaries
+    files:
+      - none*
 
 changelog:
   sort: asc


### PR DESCRIPTION
By default goreleaser will add the README to the archive. This causes gzip to error. We don't really want the README, so this config excludes it, packaging only the binary.